### PR TITLE
chore: move dev command to top

### DIFF
--- a/src/Helpers/index.ts
+++ b/src/Helpers/index.ts
@@ -123,9 +123,9 @@ export async function getState(
   pkg.set('name', options.projectName)
   pkg.set('version', '1.0.0')
   pkg.set('private', true)
+  pkg.setScript('dev', 'node ace serve --watch')
   pkg.setScript('build', 'node ace build --production')
   pkg.setScript('start', 'node server.js')
-  pkg.setScript('dev', 'node ace serve --watch')
 
   /**
    * Set environment variables that can be used by the packages


### PR DESCRIPTION
Feels more natural in the context of VSCode (`dev` is what we run most of the times so it nicer for it to be first)

Currently:
![2021-03-27_103755](https://user-images.githubusercontent.com/11320080/112715414-bd096b00-8ee8-11eb-952a-6ba795c185e4.png)

