### PR TITLE
feat: support pnpm to install new applications

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,7 +16,7 @@ import { tasks } from './Tasks'
 import { greet } from './src/Chalk/greet'
 import { showArt } from './src/Chalk/art'
 import { getHelp } from './src/Chalk/help'
-import { getState, usingYarn } from './src/Helpers'
+import { getState, packageManager } from './src/Helpers'
 
 /**
  * Running all the tasks to create a new project.
@@ -42,7 +42,7 @@ export async function runTasks(args: string[]) {
    * Show help when no arguments are passed
    */
   if (!argv._.length) {
-    console.log(getHelp(usingYarn))
+    console.log(getHelp(packageManager))
     return
   }
 
@@ -58,7 +58,7 @@ export async function runTasks(args: string[]) {
    * Setup state
    */
   const state = await getState(projectPath, {
-    client: usingYarn ? 'yarn' : 'npm',
+    client: packageManager,
     projectName: argv.name,
     debug: argv.debug,
     boilerplate: argv.boilerplate,

--- a/src/Chalk/help.ts
+++ b/src/Chalk/help.ts
@@ -8,31 +8,39 @@
  */
 
 import { logger } from '@adonisjs/sink'
+import type { SupportedPackageManager } from '../Helpers'
 
 /**
  * Text to show on the help screen. Its simple and hence writing it
  * by hand is fine
  */
-export const getHelp = (yarn: boolean) => `${logger.colors.green(
-  yarn ? 'yarn create adonis-ts-app' : 'npm init adonis-ts-app'
-)} ${logger.colors.dim('<project-name>')}
+export const getHelp = (packageManager: SupportedPackageManager) => {
+  const runSentence =
+    packageManager === 'yarn'
+      ? 'yarn create adonis-ts-app'
+      : packageManager === 'pnpm'
+      ? 'pnpm init adonis-ts-app'
+      : 'npm init adonis-ts-app'
+
+  return `${logger.colors.green(runSentence)} ${logger.colors.dim('<project-name>')}
 
 ${logger.colors.yellow().bold('Options')}
 ${logger.colors.green('--boilerplate')} ${logger.colors.dim(
-  '[api, web, slim]'
-)}    ${logger.colors.dim('Select the project boilerplate')}
+    '[api, web, slim]'
+  )}    ${logger.colors.dim('Select the project boilerplate')}
 ${logger.colors.green('--name')} ${logger.colors.dim(
-  '<string>'
-)}                   ${logger.colors.dim('Specify application name')}
+    '<string>'
+  )}                   ${logger.colors.dim('Specify application name')}
 ${logger.colors.green('--eslint')} ${logger.colors.dim(
-  '<boolean>'
-)}                ${logger.colors.dim('Enable/disable eslint setup')}
+    '<boolean>'
+  )}                ${logger.colors.dim('Enable/disable eslint setup')}
 ${logger.colors.green('--prettier')} ${logger.colors.dim(
-  '<boolean>'
-)}              ${logger.colors.dim('Enable/disable prettier setup')}
+    '<boolean>'
+  )}              ${logger.colors.dim('Enable/disable prettier setup')}
 ${logger.colors.green('--encore')} ${logger.colors.dim(
-  '<boolean>'
-)}                ${logger.colors.dim('Enable/disable encore setup')}
+    '<boolean>'
+  )}                ${logger.colors.dim('Enable/disable encore setup')}
 ${logger.colors.green('--debug')} ${logger.colors.dim(
-  '<boolean>'
-)}                 ${logger.colors.dim('Turn on the debug mode')}`
+    '<boolean>'
+  )}                 ${logger.colors.dim('Turn on the debug mode')}`
+}

--- a/src/Contracts/index.ts
+++ b/src/Contracts/index.ts
@@ -9,6 +9,7 @@
 
 import { logger as sinkLogger, files } from '@adonisjs/sink'
 import { ApplicationContract } from '@ioc:Adonis/Core/Application'
+import type { SupportedPackageManager } from '../Helpers'
 
 /**
  * Shape of task functions
@@ -26,7 +27,7 @@ export type CliState = {
   baseName: string
   absPath: string
   debug: boolean
-  client: 'yarn' | 'npm'
+  client: SupportedPackageManager
   boilerplate: 'web' | 'api' | 'slim'
   projectName: string
   eslint: boolean

--- a/src/Helpers/index.ts
+++ b/src/Helpers/index.ts
@@ -30,7 +30,7 @@ export async function getState(
     projectName?: string
     eslint?: boolean
     prettier?: boolean
-    client: 'yarn' | 'npm'
+    client: SupportedPackageManager
     encore?: boolean
   }
 ): Promise<CliState> {
@@ -197,7 +197,14 @@ export function getInstallMessage(list: string[]): string {
   return dependencies.join(', ')
 }
 
+export type SupportedPackageManager = typeof packageManager
+
 /**
- * Find if process is a child process of yarn or not
+ * Detect what package manager is in used, fallback to npm.
  */
-export const usingYarn = !!(process.env.npm_execpath && process.env.npm_execpath.includes('yarn'))
+export const packageManager =
+  process.env.npm_execpath && process.env.npm_execpath.includes('yarn')
+    ? 'yarn'
+    : process.env.npm_execpath && process.env.npm_execpath.includes('pnpm')
+    ? 'pnpm'
+    : 'npm'

--- a/tasks/InstallDependencies/index.ts
+++ b/tasks/InstallDependencies/index.ts
@@ -17,10 +17,10 @@ import { packages } from '../../src/Schematics/packages'
  */
 const task: TaskFn = async (_, logger, { pkg, client, boilerplate, debug }) => {
   /**
-   * Set by `yarn create`
+   * Set the wanted client
    */
-  if (client === 'yarn') {
-    pkg.yarn(true)
+  if (client !== 'npm') {
+    pkg.useClient(client)
   }
 
   /**
@@ -79,7 +79,12 @@ const task: TaskFn = async (_, logger, { pkg, client, boilerplate, debug }) => {
   spinner && spinner.stop()
 
   if (response && response.status === 1) {
-    const errorMessage = client === 'yarn' ? 'yarn install failed' : 'npm install failed'
+    const errorMessage =
+      client === 'yarn'
+        ? 'yarn install failed'
+        : client === 'pnpm'
+        ? 'pnpm install failed'
+        : 'npm install failed'
     const error = new Error(errorMessage)
     error['stack'] = response.stderr.toString()
     throw error


### PR DESCRIPTION
Hey! 👋🏻 

This PR add the support to use `pnpm` to install new application.
The command `pnpm init adonis-ts-app foo` will now use `pnpm` to install needed dependencies.

In order to work, https://github.com/adonisjs/sink/pull/19 need to be merged and released.