### PR TITLE
fix: use npm module rather than path in tsconfig

### DIFF
--- a/tasks/Scaffold/createTsConfig.ts
+++ b/tasks/Scaffold/createTsConfig.ts
@@ -19,11 +19,6 @@ const task: TaskFn = (_, logger, { absPath }) => {
   /**
    * Use a base config file
    */
-
-  /**
-   * Analyze the project and see if a node_modules exists in the top folder,
-   * which case it might mean we're on a monorepo.
-   */
   tsconfig.set('extends', 'adonis-preset-ts/tsconfig.json')
 
   /**

--- a/tasks/Scaffold/createTsConfig.ts
+++ b/tasks/Scaffold/createTsConfig.ts
@@ -19,7 +19,12 @@ const task: TaskFn = (_, logger, { absPath }) => {
   /**
    * Use a base config file
    */
-  tsconfig.set('extends', './node_modules/adonis-preset-ts/tsconfig')
+
+  /**
+   * Analyze the project and see if a node_modules exists in the top folder,
+   * which case it might mean we're on a monorepo.
+   */
+  tsconfig.set('extends', 'adonis-preset-ts/tsconfig.json')
 
   /**
    * Include everything


### PR DESCRIPTION
## Proposed changes

This change propose to use the package's name of `adonis-preset-ts` in the `tsconfig.json` rather than using a path that may lead to confusion, most especially in Monorepo configurations or such.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/AdonisCommunity/create-adonis-ts-app/blob/master/CONTRIBUTING.md) doc
- [x] Lint pass locally with my changes
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Closes adonisjs/assembler#42.