### PR TITLE
chore: install missing types packages

### DIFF
--- a/tasks/InstallDependencies/index.ts
+++ b/tasks/InstallDependencies/index.ts
@@ -47,6 +47,8 @@ const task: TaskFn = async (_, logger, { pkg, client, boilerplate, debug }) => {
   pkg.install('pino-pretty')
   pkg.install('adonis-preset-ts')
   pkg.install('@adonisjs/assembler')
+  pkg.install('@types/source-map-support')
+  pkg.install('@types/proxy-addr')
 
   /**
    * Displaying a spinner, since install packages takes


### PR DESCRIPTION
I just initialized a new Adonis app with typescript in a very strict mode.

I realized that we were missing these two types packages 