### PR TITLE
fix: add baseUrl to tsconfig generated

### DIFF
--- a/tasks/Scaffold/createTsConfig.ts
+++ b/tasks/Scaffold/createTsConfig.ts
@@ -37,6 +37,7 @@ const task: TaskFn = (_, logger, { absPath }) => {
   tsconfig.set('compilerOptions', {
     outDir: 'build',
     rootDir: './',
+    baseUrl: './',
     sourceMap: true,
     paths: {
       'App/*': ['./app/*'],


### PR DESCRIPTION
## Proposed changes

When you create an app and upgrade the Typescript version to `~4.9` (latest), the aliases no longer works with TS and IntelliSense (tested with VSCode)

![image](https://user-images.githubusercontent.com/12446546/206456016-63ab66fe-92a2-499d-9377-e28e42c812f1.png)

To fix it, we have to add the `baseUrl` with `./` (like `rootDir` already set) in compilerOptions in the `tsconfig.json`.
 
## Types of changes

What types of changes does your code introduce?

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/AdonisCommunity/create-adonis-ts-app/blob/master/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes 
**No tests provided in the project and japa not support typescript ~4.9**
- [ ] I have added tests that prove my fix is effective or that my feature works.
**No tests already added**
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
